### PR TITLE
Can't detect firefox

### DIFF
--- a/src/conf/docker.conf.js
+++ b/src/conf/docker.conf.js
@@ -25,7 +25,8 @@ const dockerConfig = {
       browserName: 'firefox',
       browserVersion: 'latest',
       'moz:firefoxOptions': {
-        args: ['-headless']
+        args: ['-headless'],
+        binary: '/usr/bin/firefox'
       }
     }
   ],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4443

Acceptance tests are failing to run as it cannot detect Firefox browser.

The error is "Error: Couldn't find a matching firefox browser for tag "135.0a1" on platform "linux""