### PR TITLE
Resolve apt-key removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ ENV TZ=Europe/London
 RUN set -ex; \
     apt-get update; \
     apt-get upgrade -y; \
-    apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
+    apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential
 
 # Install google-chrome repo
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN /bin/sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg
+RUN /bin/sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 
 # Install Chrome
 RUN	apt-get update; \

--- a/src/conf/docker.conf.js
+++ b/src/conf/docker.conf.js
@@ -2,12 +2,13 @@ import { commonConfig } from './common.conf.js'
 
 export const config = {
   ...commonConfig,
+  xvfb: false,
   capabilities: [
     {
       browserName: 'chrome',
       browserVersion: 'stable',
       'goog:chromeOptions': {
-        args: ['--headless', '--disable-gpu', '--no-sandbox']
+        args: ['--headless=new', '--disable-gpu', '--no-sandbox']
       }
     },
     {


### PR DESCRIPTION
apt-key has been removed from newer Debian/Ubuntu base images, so we need to store the GPG key as a keyring file

This replicates the solution from https://github.com/DEFRA/rod-licensing-tests/pull/303